### PR TITLE
Refinements

### DIFF
--- a/_concerns/pay-child-labor.md
+++ b/_concerns/pay-child-labor.md
@@ -4,7 +4,9 @@ title: Child labor
 layout: concern-details
 
 # Metadata
-concern: I want to report a different issue
+concern:
+  - I want to report a different issue
+  - I wasn’t paid properly
 detail: child labor
 right: pay
 summary: "I think someone is employing children unlawfully"

--- a/_concerns/safety-retaliation.md
+++ b/_concerns/safety-retaliation.md
@@ -4,7 +4,9 @@ title: Whistleblower protections
 layout: concern-details
 
 # Metadata
-concern: I don’t feel safe at work
+concern:
+  - I don’t feel safe at work
+  - I was harassed, threatened, or retaliated against
 detail: whistleblower
 right: safety-rights
 summary: "I was fired or threatened for reporting a safety issue"

--- a/_layouts/all-concerns.html
+++ b/_layouts/all-concerns.html
@@ -9,17 +9,17 @@ layout: content
 <div class="usa-grid section">
   <div class="usa-width-three-fourths">
     <ul class="usa-accordion">
-      {% assign concerns = site.concerns | map:'concern' | uniq %}
-      {% for concern in concerns %}
+      {% for concern in page.concerns %}
         <li id="{{ concern | slugify }}">
           <button class="usa-accordion-button concern__button js-concern-button" aria-controls="accordion-{{ concern | slugify }}">
             <h3>{{ concern }}</h3>
           </button>
           <div class="concern__details usa-accordion-content js-concern-details" id="accordion-{{ concern | slugify }}">
-            {% assign details = site.concerns | where:'concern',concern %}
             <ul>
-              {% for detail in details %}
+              {% for detail in site.concerns %}
+                {% if detail.concern contains concern or detail.concern == concern %}
                 <li><a class="concern__detail" href="{{ detail.url | prepend:site.baseurl }}">{{ detail.summary }} &raquo;</a></li>
+                {% endif %}
               {% endfor %}
             </ul>
           </div>

--- a/_layouts/all-concerns.html
+++ b/_layouts/all-concerns.html
@@ -3,11 +3,16 @@ layout: content
 ---
 
 <div class="usa-grid">
-  <h1>Workplace concerns</h1>
-  {{ page.content }}
+  <div class="usa-width-three-fourths">
+    <h1>Workplace concerns</h1>
+    {{ page.content }}
+  </div>
 </div>
 <div class="usa-grid section">
   <div class="usa-width-three-fourths">
+    <div class="usa-grid accordion-controls">
+      <button class="toggle-button" id="toggle-all" data-action="expand">Expand all</button>
+    </div>
     <ul class="usa-accordion">
       {% for concern in page.concerns %}
         <li id="{{ concern | slugify }}">
@@ -24,10 +29,7 @@ layout: content
             </ul>
           </div>
         </li>
-
       {% endfor %}
-
-
     </div>
   </div>
 </div>

--- a/_layouts/process.html
+++ b/_layouts/process.html
@@ -3,32 +3,36 @@ layout: default
 ---
 
 <section class="section">
-
-	<div class="usa-grid">
+	<div class="usa-grid section">
 		<h1>{{page.header}}</h1>
-		<div class="main-content">
+		<div class="main-content section">
 			{% if page.before-you-file-markup %}
 				<h2>Before you file</h2>
 				{{ page.before-you-file-markup }}
 			{% endif %}
-				<h2>What can I expect?</h2>
-				<div class="steps">
-					<ul class="usa-unstyled-list">
-					  {% for step in page.steps %}
-						<li>
-							<div class="step-img">
-			  					<img src="{{step.img | prepend: site.baseurl }}"/>
-			  				</div>
-								<div class="step-content">
-			  					<h4>Step {{ forloop.index }}</h4>
-			  					<p>{{step.text}}</p>
-								</div>
-						</li>
-				   {% endfor %}
-					</ul>
+				<div class="section">
+					<h2>What can I expect?</h2>
+					<div class="steps">
+						<ul class="usa-unstyled-list">
+						  {% for step in page.steps %}
+							<li>
+								<div class="step-img">
+				  					<img src="{{step.img | prepend: site.baseurl }}"/>
+				  				</div>
+									<div class="step-content">
+				  					<h4>Step {{ forloop.index }}</h4>
+				  					<p>{{step.text}}</p>
+									</div>
+							</li>
+					   {% endfor %}
+						</ul>
+						<div class="step-content">
+							<a class="usa-button usa-button-big" href="{{page.exit}}" class="exit">File Now</a>
+						</div>
+					</div>
 				</div>
 			</div>
-			<aside class="sidebar sidebar__box sidebar__box--gray">
+			<aside class="sidebar sidebar__box sidebar__box--blue">
 				<h3>We're here to help</h3>
 				<ul class="no-bullets">
 				{% for help in page.here-to-help %}
@@ -37,16 +41,6 @@ layout: default
 				</ul>
 			</aside>
 		</div>
-	<div class="usa-grid">
-		<div class="usa-width-one-whole">
-			<div class="usa-grid">
-				<div class="usa-width-one-whole">
-					<a class="usa-button usa-button-big" href="{{page.exit}}" class="exit">File Now</a>
-				</div>
-			</div>
-		</div>
-	</div>
-
 	{{ content }}
 
 </section>

--- a/_sass/worker/_concerns.scss
+++ b/_sass/worker/_concerns.scss
@@ -54,3 +54,22 @@
     text-decoration: none;
   }
 }
+
+.toggle-button {
+  float: right;
+  font-weight: normal;
+  background: none;
+  color: $color-primary;
+  padding: 0;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background: none;
+    color: $color-primary-darker;
+  }
+}
+
+.accordion-controls {
+  padding: 0 0 1rem 0;
+}

--- a/_sass/worker/_layout.scss
+++ b/_sass/worker/_layout.scss
@@ -75,7 +75,8 @@
   padding: 2rem;
 
   h3 {
-    font-size: 2.2rem;
+    font-size: 1.7rem;
+    color: $w-gray-2;
   }
 
   & + & {

--- a/all-concerns.md
+++ b/all-concerns.md
@@ -1,5 +1,0 @@
----
-layout: all-concerns
-title: Workplace concerns
-permalink: /concerns/
----

--- a/assets/js/concerns.js
+++ b/assets/js/concerns.js
@@ -11,3 +11,36 @@ if (window.location.hash) {
   document.querySelector('[aria-controls="'+ id +'"]').setAttribute('aria-expanded', 'true');
   document.getElementById(id).removeAttribute('hidden');
 }
+
+function expandAll() {
+  [].forEach.call(details, function(detail) {
+    detail.setAttribute('aria-hidden', 'false');
+  });
+
+  [].forEach.call(concerns, function(concern) {
+    concern.setAttribute('aria-expanded', 'true');
+  });
+}
+
+function collapseAll() {
+  [].forEach.call(details, function(detail) {
+    detail.setAttribute('aria-hidden', 'true');
+  });
+
+  [].forEach.call(concerns, function(concern) {
+    concern.setAttribute('aria-expanded', 'false');
+  });
+}
+
+document.getElementById('toggle-all').addEventListener('click', function(e) {
+  var toggleButton = e.target;
+  if (toggleButton.dataset.action == 'expand') {
+    expandAll();
+    toggleButton.dataset.action = 'collapse';
+    toggleButton.innerText = 'Collapse all';
+  } else {
+    collapseAll();
+    toggleButton.dataset.action = 'expand';
+    toggleButton.innerText = 'Expand all';
+  }
+});

--- a/index.html
+++ b/index.html
@@ -44,9 +44,13 @@ title: Home
         <strong><a class="t-medium" href="{{ "/concerns" | prepend:site.baseurl }}">View all concerns</a></strong>
       </div>
       <div class="usa-width-one-third sidebar__box">
-        {% assign concerns = site.concerns | map:'concern' | uniq %}
         <h3>Workplace concerns</h3>
         <ul class="no-bullets t-medium">
+          {% for page in site.pages %}
+            {% if page.name == 'workplace-concerns.md' %}
+              {% assign concerns = page.concerns %}
+            {% endif %}
+          {% endfor %}
           {% for concern in concerns %}
           <li><a href="{{ site.baseurl }}/concerns#{{ concern | slugify }}">{{ concern }}</a></li>
           {% endfor %}
@@ -63,13 +67,3 @@ title: Home
       </div>
     </div>
   </section>
-
-<script>
-var select = document.getElementById('concern-select');
-select.addEventListener('change', function(e) {
-  var hash = e.target.value;
-  var a = document.getElementById('concern-button');
-  var url = a.getAttribute('href') + '#' + hash;
-  a.setAttribute('href', url);
-});
-</script>

--- a/workplace-concerns.md
+++ b/workplace-concerns.md
@@ -1,0 +1,17 @@
+---
+layout: all-concerns
+title: Workplace concerns
+permalink: /concerns/
+
+# This controls the order of the accordions
+concerns:
+  - I was harassed, threatened, or retaliated against
+  - I don’t feel safe at work
+  - I was treated unfairly
+  - I wasn’t paid properly
+  - I was fired or not hired
+  - I want to report a different issue
+
+---
+
+Aenean lacinia bibendum nulla sed consectetur. Maecenas faucibus mollis interdum. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec id elit non mi porta gravida at eget metus.


### PR DESCRIPTION
This adds a few more features:

- Expand all / collapse all:
![expand](http://g.recordit.co/vtMlIOLrlA.gif)

- Concern examples can now map to multiple concerns. The way to do this is to format the frontmatter like so:

```yaml
concern:
  - I don’t feel safe at work
  - I was harassed, threatened, or retaliated against
```

[Example](https://raw.githubusercontent.com/18F/worker-dol-gov/58e3f937fce2f8f7d74791d1e198943923f34164/_concerns/safety-retaliation.md). If there's only one concern, nothing needs to change.

- The names and order of the concerns on the all concerns page and the home page are now controlled by the order of them in the data for the `workplace-concerns.md` [page](https://github.com/18F/worker-dol-gov/blob/58e3f937fce2f8f7d74791d1e198943923f34164/workplace-concerns.md). This allows custom ordering. **IMPORTANT:** This means that the wording of the concerns of the detailed files needs to match these items exactly, otherwise they won't show up.

- Cleans up the styling of the action page